### PR TITLE
Moved thorns to effect

### DIFF
--- a/content/blocks/thorns.hjson
+++ b/content/blocks/thorns.hjson
@@ -9,5 +9,5 @@ requirements: [
 	scrap/4
 ]
 
-category: defense
+category: effect
 research: sieve


### PR DESCRIPTION
Please move thorns to effect. Thorns do the same thing as shock mines do without the lighting and with less damage/durability.